### PR TITLE
アイテムの拡大表示処理を実装

### DIFF
--- a/Assets/Scenes/WhiteRoom.unity
+++ b/Assets/Scenes/WhiteRoom.unity
@@ -3552,7 +3552,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -4337,6 +4337,7 @@ GameObject:
   - component: {fileID: 589439196}
   - component: {fileID: 589439198}
   - component: {fileID: 589439199}
+  - component: {fileID: 589439200}
   m_Layer: 5
   m_Name: Slot0
   m_TagString: Untagged
@@ -4460,6 +4461,18 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 589439200}
+        m_TargetAssemblyTypeName: ZoomPanel, Assembly-CSharp
+        m_MethodName: ChangePanel
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 1266694063}
         m_TargetAssemblyTypeName: ItemBox, Assembly-CSharp
         m_MethodName: OnSelectSlot
@@ -4472,6 +4485,22 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &589439200
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589439194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ddce4cae073614a1f8f6ab467c008b0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  panel: {fileID: 1012040119}
+  rightArrow: {fileID: 1713534527}
+  leftArrow: {fileID: 1813743167}
+  backArrow: {fileID: 2093211434}
 --- !u!1 &593599126
 GameObject:
   m_ObjectHideFlags: 0
@@ -6200,6 +6229,82 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1012040119
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1012040120}
+  - component: {fileID: 1012040122}
+  - component: {fileID: 1012040121}
+  m_Layer: 5
+  m_Name: BGPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1012040120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012040119}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1999097844}
+  m_Father: {fileID: 1897657091}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 196.21}
+  m_SizeDelta: {x: 715, y: 730}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1012040121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012040119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.49803922, g: 0.49803922, b: 0.49803922, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1012040122
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012040119}
+  m_CullTransparentMesh: 1
 --- !u!1 &1107564418
 GameObject:
   m_ObjectHideFlags: 0
@@ -7208,6 +7313,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slots: []
   selectedSlot: {fileID: 0}
+  selectCount: 0
   slotsCount: 0
 --- !u!1 &1275939277
 GameObject:
@@ -9853,7 +9959,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -10775,7 +10881,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -11189,6 +11295,106 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1881014253}
   m_CullTransparentMesh: 1
+--- !u!1 &1897657087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1897657091}
+  - component: {fileID: 1897657090}
+  - component: {fileID: 1897657089}
+  - component: {fileID: 1897657088}
+  m_Layer: 5
+  m_Name: ZoomCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1897657088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897657087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1897657089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897657087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 750, y: 1334}
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1897657090
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897657087}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 519420031}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 1
+  m_TargetDisplay: 0
+--- !u!224 &1897657091
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897657087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1012040120}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1899741786
 GameObject:
   m_ObjectHideFlags: 0
@@ -11746,6 +11952,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1990967816}
+  m_CullTransparentMesh: 1
+--- !u!1 &1999097843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1999097844}
+  - component: {fileID: 1999097846}
+  - component: {fileID: 1999097845}
+  m_Layer: 5
+  m_Name: ZoomImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1999097844
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999097843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1012040120}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 500, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1999097845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999097843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1999097846
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999097843}
   m_CullTransparentMesh: 1
 --- !u!1 &2001417741
 GameObject:
@@ -12398,7 +12679,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -12426,6 +12707,18 @@ MonoBehaviour:
       - m_Target: {fileID: 1326768897}
         m_TargetAssemblyTypeName: WallChanger, Assembly-CSharp
         m_MethodName: OnBackButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 589439200}
+        m_TargetAssemblyTypeName: ZoomPanel, Assembly-CSharp
+        m_MethodName: ClosePanel
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/Gimmick/Gimmick.cs
+++ b/Assets/Scripts/Gimmick/Gimmick.cs
@@ -4,25 +4,25 @@ using UnityEngine;
 
 public class Gimmick : MonoBehaviour
 {
-  [SerializeField] Item.Type clearItemType;
-  [SerializeField] GameObject Crashed;
+    [SerializeField] Item.Type clearItemType;
+    [SerializeField] GameObject Crashed;
 
-  // クリックした時
-  // ハンマーを持っていて選択していたら
-  // 削除(非表示)
+    // クリックした時
+    // ハンマーを持っていて選択していたら
+    // 削除(非表示)
 
-  // クリック判定
-  // アイテム所持判定
+    // クリック判定
+    // アイテム所持判定
 
-  public void OnClickObj()
-  {
-    // アイテムHammerを持っているかどうか
-    bool clear = ItemBox.instance.TryUseItem(clearItemType);
-    if (clear)
+    public void OnClickObj()
     {
-      // 壊れる前の壁を削除
-      gameObject.SetActive(false);
-      Crashed.SetActive(true);
+        // アイテムHammerを持っているかどうか
+        bool clear = ItemBox.instance.TryUseItem(clearItemType);
+        if (clear)
+        {
+            // 壊れる前の壁を削除
+            gameObject.SetActive(false);
+            Crashed.SetActive(true);
+        }
     }
-  }
 }

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -6,20 +6,20 @@ using UnityEngine;
 [Serializable]
 public class Item
 {
-  public enum Type
-  {
-    Reversi,
-    HintCard1,
-    Hammer,
-  }
+    public enum Type
+    {
+        Reversi,
+        HintCard1,
+        Hammer,
+    }
 
-  public Type type;         // 種類
-  public Sprite sprite;     // Slotに表示する画像
+    public Type type;         // 種類
+    public Sprite sprite;     // Slotに表示する画像
 
-  // 型
-  public Item(Type type, Sprite sprite)
-  {
-    this.type = type;
-    this.sprite = sprite;
-  }
+    // 型
+    public Item(Type type, Sprite sprite)
+    {
+        this.type = type;
+        this.sprite = sprite;
+    }
 }

--- a/Assets/Scripts/ItemBox.cs
+++ b/Assets/Scripts/ItemBox.cs
@@ -7,7 +7,6 @@ public class ItemBox : MonoBehaviour
 {
     [SerializeField] Slot[] slots;
     [SerializeField] Slot selectedSlot = null;
-    public int selectCount = 0;
 
     // アイテム使用後のitemを持つslotの数をカウントするための変数
     public int slotsCount = 0;
@@ -51,14 +50,6 @@ public class ItemBox : MonoBehaviour
         if (slots[position].OnSelected())
         {
             selectedSlot = slots[position];
-            if (selectCount == 0)
-            {
-                selectCount = 1;
-            }
-            else
-            {
-                return;
-            }
         }
     }
 

--- a/Assets/Scripts/ItemBox.cs
+++ b/Assets/Scripts/ItemBox.cs
@@ -5,119 +5,138 @@ using UnityEngine;
 
 public class ItemBox : MonoBehaviour
 {
-  [SerializeField] Slot[] slots;
-  [SerializeField] Slot selectedSlot = null;
+    [SerializeField] Slot[] slots;
+    [SerializeField] Slot selectedSlot = null;
+    public int selectCount = 0;
 
-  // アイテム使用後のitemを持つslotの数をカウントするための変数
-  public int slotsCount = 0;
+    // アイテム使用後のitemを持つslotの数をカウントするための変数
+    public int slotsCount = 0;
 
-  // どこでも実行できるようにstatic化
-  public static ItemBox instance;
-  private void Awake()
-  {
-    if (instance == null)
+    // どこでも実行できるようにstatic化
+    public static ItemBox instance;
+    private void Awake()
     {
-      instance = this;
+        if (instance == null)
+        {
+            instance = this;
 
-      // slots配列にslot要素をコードから挿入
-      slots = GetComponentsInChildren<Slot>();
+            // slots配列にslot要素をコードから挿入
+            slots = GetComponentsInChildren<Slot>();
+        }
     }
-  }
 
-  // PickupObjがタップされたら、アイテムBOXに格納
-  public void SetItem(Item item)
-  {
-    foreach (Slot slot in slots)
+    // PickupObjがタップされたら、アイテムBOXに格納
+    public void SetItem(Item item)
     {
-      // Slotsを1つずつ見て、空いてたら画像(itemも)を入れる
-      if (slot.IsEmpty())
-      {
-        slot.SetItem(item);
-        break;
-      }
+        foreach (Slot slot in slots)
+        {
+            // Slotsを1つずつ見て、空いてたら画像(itemも)を入れる
+            if (slot.IsEmpty())
+            {
+                slot.SetItem(item);
+                break;
+            }
+        }
     }
-  }
 
-  // アイテムBOX内にあるアイテムをタップした時にアイテム周辺に枠ができる
-  public void OnSelectSlot(int position)
-  {
-    // 一旦全てのスロットの選択フレームを非表示
-    foreach (Slot slot in slots)
+    // アイテムBOX内にあるアイテムをタップした時にアイテム周辺に枠ができる
+    public void OnSelectSlot(int position)
     {
-      slot.HideFrame();
+        // 一旦全てのスロットの選択フレームを非表示
+        foreach (Slot slot in slots)
+        {
+            slot.HideFrame();
+        }
+        // 選択されたスロットの選択フレームを表示
+        if (slots[position].OnSelected())
+        {
+            selectedSlot = slots[position];
+            if (selectCount == 0)
+            {
+                selectCount = 1;
+            }
+            else
+            {
+                return;
+            }
+        }
     }
-    // 選択されたスロットの選択フレームを表示
-    if (slots[position].OnSelected())
+
+    // アイテムの使用/使えるなら使う
+    public bool TryUseItem(Item.Type type)
     {
-      selectedSlot = slots[position];
-    }
-  }
+        // 選択スロットがあるかどうか
+        if (selectedSlot == null)
+        {
+            return false;
+        }
+        // Hammerを選択しているか
+        if (selectedSlot.GetItem().type != type)
+        {
+            return false;
+        }
+        selectedSlot.SetItem(null);
 
-  // アイテムの使用/使えるなら使う
-  public bool TryUseItem(Item.Type type)
-  {
-    // 選択スロットがあるかどうか
-    if (selectedSlot == null)
+        return true;
+
+        // itemが入っているslotの数を確認
+        // foreach (Slot slot in slots)
+        // {
+        //   if (slot.GetItem() != null)
+        //   {
+        //     slotsCount++;
+        //   }
+        // }
+
+        // アイテム使用後に、itemを持っているslotが1つ以上でもあれば実行
+        // 使用したスロット以降の要素を使用したスロット(選択したスロットselectedSlot)を開始位置として最後の要素までCopyする
+        // 4つアイテムを持ってて、1つ目を使った場合、後ろ3つの要素が左に一つずれる
+        // 4つアイテムを持ってて、2つ目を使った場合、後ろ2つの要素が左に一つずれる
+        // ずらす要素数は 配列の長さ-(使用したスロット位置+1) でできそう
+
+        // if (slotsCount >= 1)
+        // {
+        //   Array.Copy(slots, Array.IndexOf(slots, selectedSlot) + 1, slots, Array.IndexOf(slots, selectedSlot), slots.Length - (Array.IndexOf(slots, selectedSlot) + 1));
+
+        //   // slots[i]からスロットのImageコンポーネントを取得する必要がある
+
+        //   for (int i = 0; i < slotsCount; i++)
+        //   {
+        //     // slotのimageにitemのimageを入れる
+        //     slots[i].image.sprite = slots[i].GetItem().sprite;
+        //     Debug.Log(slots[i].GetItem().sprite);
+        //     Debug.Log(slots[i].GetItem().type);
+        //   }
+        // }
+
+        // 全てのアイテムBOX画像を削除
+
+        // // 子オブジェクトを返却する配列作成
+        // var children = new Transform[parent.childCount];
+        // var childIndex = 0;
+
+        // // 子オブジェクトを順番に配列に格納
+        // foreach (Transform child in parent)
+        // {
+        //   children[childIndex++] = child;
+        // }
+
+        // for (int i = 0; i < slots.Length; i++)
+        // {
+        //   Sprite[] slotsSprites = itemBox.GetComponentInChildren<Sprite[]>();
+        //   slotsSprites[i] = null;
+        // }
+
+        // Itemに設定されている画像を表示
+    }
+
+    // ZoomPanelスクリプトのShowPanel関数で実行
+    public Item GetSelectedItem()
     {
-      return false;
+        if (selectedSlot == null)
+        {
+            return null;
+        }
+        return selectedSlot.GetItem();
     }
-    // Hammerを選択しているか
-    if (selectedSlot.GetItem().type != type)
-    {
-      return false;
-    }
-    selectedSlot.SetItem(null);
-
-    return true;
-
-    // itemが入っているslotの数を確認
-    // foreach (Slot slot in slots)
-    // {
-    //   if (slot.GetItem() != null)
-    //   {
-    //     slotsCount++;
-    //   }
-    // }
-
-    // アイテム使用後に、itemを持っているslotが1つ以上でもあれば実行
-    // 使用したスロット以降の要素を使用したスロット(選択したスロットselectedSlot)を開始位置として最後の要素までCopyする
-    // 4つアイテムを持ってて、1つ目を使った場合、後ろ3つの要素が左に一つずれる
-    // 4つアイテムを持ってて、2つ目を使った場合、後ろ2つの要素が左に一つずれる
-    // ずらす要素数は 配列の長さ-(使用したスロット位置+1) でできそう
-
-    // if (slotsCount >= 1)
-    // {
-    //   Array.Copy(slots, Array.IndexOf(slots, selectedSlot) + 1, slots, Array.IndexOf(slots, selectedSlot), slots.Length - (Array.IndexOf(slots, selectedSlot) + 1));
-
-    //   // slots[i]からスロットのImageコンポーネントを取得する必要がある
-
-    //   for (int i = 0; i < slotsCount; i++)
-    //   {
-    //     // slotのimageにitemのimageを入れる
-    //     slots[i].image.sprite = slots[i].GetItem().sprite;
-    //     Debug.Log(slots[i].GetItem().sprite);
-    //     Debug.Log(slots[i].GetItem().type);
-    //   }
-    // }
-
-    // 全てのアイテムBOX画像を削除
-
-    // // 子オブジェクトを返却する配列作成
-    // var children = new Transform[parent.childCount];
-    // var childIndex = 0;
-
-    // // 子オブジェクトを順番に配列に格納
-    // foreach (Transform child in parent)
-    // {
-    //   children[childIndex++] = child;
-    // }
-
-    // for (int i = 0; i < slots.Length; i++)
-    // {
-    //   Sprite[] slotsSprites = itemBox.GetComponentInChildren<Sprite[]>();
-    //   slotsSprites[i] = null;
-    // }
-
-    // Itemに設定されている画像を表示
-  }
 }

--- a/Assets/Scripts/ItemGenerator.cs
+++ b/Assets/Scripts/ItemGenerator.cs
@@ -4,27 +4,27 @@ using UnityEngine;
 
 public class ItemGenerator : MonoBehaviour
 {
-  [SerializeField] ItemListEntity itemListEntity;
+    [SerializeField] ItemListEntity itemListEntity;
 
-  public static ItemGenerator instance;
-  private void Awake()
-  {
-    if (instance == null)
+    public static ItemGenerator instance;
+    private void Awake()
     {
-      instance = this;
+        if (instance == null)
+        {
+            instance = this;
+        }
     }
-  }
 
-  public Item Spawn(Item.Type type)
-  {
-    // itemListの中からtypeと一致するitemインスタンスを生成して渡す
-    foreach (Item item in itemListEntity.itemList)
+    public Item Spawn(Item.Type type)
     {
-      if (item.type == type)
-      {
-        return new Item(item.type, item.sprite);
-      }
+        // itemListの中からtypeと一致するitemインスタンスを生成して渡す
+        foreach (Item item in itemListEntity.itemList)
+        {
+            if (item.type == type)
+            {
+                return new Item(item.type, item.sprite);
+            }
+        }
+        return null;
     }
-    return null;
-  }
 }

--- a/Assets/Scripts/ItemListEntity.cs
+++ b/Assets/Scripts/ItemListEntity.cs
@@ -5,5 +5,5 @@ using UnityEngine;
 [CreateAssetMenu]
 public class ItemListEntity : ScriptableObject
 {
-  public List<Item> itemList = new List<Item>();
+    public List<Item> itemList = new List<Item>();
 }

--- a/Assets/Scripts/PickupObj.cs
+++ b/Assets/Scripts/PickupObj.cs
@@ -4,18 +4,18 @@ using UnityEngine;
 
 public class PickupObj : MonoBehaviour
 {
-  [SerializeField] Item.Type itemType;
-  Item item;
+    [SerializeField] Item.Type itemType;
+    Item item;
 
-  private void Start()
-  {
-    // itemTypeに応じてitemを生成(アイテムに対してTypeとSpriteを設定する)
-    item = ItemGenerator.instance.Spawn(itemType);
-  }
+    private void Start()
+    {
+        // itemTypeに応じてitemを生成(アイテムに対してTypeとSpriteを設定する)
+        item = ItemGenerator.instance.Spawn(itemType);
+    }
 
-  public void OnClickObj()
-  {
-    ItemBox.instance.SetItem(item);
-    gameObject.SetActive(false);
-  }
+    public void OnClickObj()
+    {
+        ItemBox.instance.SetItem(item);
+        gameObject.SetActive(false);
+    }
 }

--- a/Assets/Scripts/Slot.cs
+++ b/Assets/Scripts/Slot.cs
@@ -12,6 +12,7 @@ public class Slot : MonoBehaviour
   public static Slot instance;
 
   [SerializeField] GameObject ChoiceFrame;
+  
   private void Awake()
   {
     if (instance == null)

--- a/Assets/Scripts/Slot.cs
+++ b/Assets/Scripts/Slot.cs
@@ -5,79 +5,79 @@ using UnityEngine.UI;
 
 public class Slot : MonoBehaviour
 {
-  // スロット自体のImageコンポーネント
-  public Image image;
-  Item item;
+    // スロット自体のImageコンポーネント
+    public Image image;
+    Item item;
 
-  public static Slot instance;
+    public static Slot instance;
 
-  [SerializeField] GameObject ChoiceFrame;
-  
-  private void Awake()
-  {
-    if (instance == null)
+    [SerializeField] GameObject ChoiceFrame;
+
+    private void Awake()
     {
-      instance = this;
+        if (instance == null)
+        {
+            instance = this;
+        }
+        image = GetComponent<Image>();
+        image.color = new Color(1.0f, 1.0f, 1.0f, 0.0f);
     }
-    image = GetComponent<Image>();
-    image.color = new Color(1.0f, 1.0f, 1.0f, 0.0f);
-  }
 
-  private void Start()
-  {
-    ChoiceFrame.SetActive(false);
-  }
-
-  public bool IsEmpty()
-  {
-    if (item == null)
+    private void Start()
     {
-      return true;
+        ChoiceFrame.SetActive(false);
     }
-    return false;
-  }
 
-  // アイテムを受け取ったら画像をスロットに表示する
-
-  public void SetItem(Item item)
-  {
-    this.item = item;
-    UpdateImage(item);
-  }
-
-  public Item GetItem()
-  {
-    return item;
-  }
-
-  public void UpdateImage(Item item)
-  {
-    // スロットのImageコンポーネントにPickupObjの画像を入れる
-    if (item == null)
+    public bool IsEmpty()
     {
-      image.sprite = null;
-      image.color = new Color(1.0f, 1.0f, 1.0f, 0.0f);
-      HideFrame();
+        if (item == null)
+        {
+            return true;
+        }
+        return false;
     }
-    else
-    {
-      image.sprite = item.sprite;
-      image.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
-    }
-  }
 
-  public bool OnSelected()
-  {
-    if (item == null)
-    {
-      return false;
-    }
-    ChoiceFrame.SetActive(true);
-    return true;
-  }
+    // アイテムを受け取ったら画像をスロットに表示する
 
-  public void HideFrame()
-  {
-    ChoiceFrame.SetActive(false);
-  }
+    public void SetItem(Item item)
+    {
+        this.item = item;
+        UpdateImage(item);
+    }
+
+    public Item GetItem()
+    {
+        return item;
+    }
+
+    public void UpdateImage(Item item)
+    {
+        // スロットのImageコンポーネントにPickupObjの画像を入れる
+        if (item == null)
+        {
+            image.sprite = null;
+            image.color = new Color(1.0f, 1.0f, 1.0f, 0.0f);
+            HideFrame();
+        }
+        else
+        {
+            image.sprite = item.sprite;
+            image.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+    }
+
+    public bool OnSelected()
+    {
+        if (item == null)
+        {
+            return false;
+        }
+        ChoiceFrame.SetActive(true);
+        return true;
+    }
+
+    public void HideFrame()
+    {
+        ChoiceFrame.SetActive(false);
+    }
 }

--- a/Assets/Scripts/WallChanger.cs
+++ b/Assets/Scripts/WallChanger.cs
@@ -4,330 +4,330 @@ using UnityEngine;
 
 public class WallChanger : MonoBehaviour
 {
-  public GameObject rightArrow;
-  public GameObject leftArrow;
-  public GameObject backArrow;
+    public GameObject rightArrow;
+    public GameObject leftArrow;
+    public GameObject backArrow;
 
-  enum Wall
-  {
-    Wall0,
-    Wall1,
-    Wall2,
-    Wall3,
-    Wall0_0,
-    Wall0_1,
-    Wall0_2,
-    Wall0_3,
-    Wall1_0,
-    Wall1_1,
-    Wall1_2,
-    Wall1_3,
-    Wall1_4,
-    Wall2_0,
-    Wall2_1,
-    Wall2_2,
-    Wall2_3,
-    Wall3_0,
-    Wall3_1,
-    Wall3_2,
-  }
-
-  Wall currentWall;
-
-  private void Start()
-  {
-    Show(Wall.Wall0);
-  }
-
-
-  void HideArrows()
-  {
-    rightArrow.SetActive(false);
-    leftArrow.SetActive(false);
-    backArrow.SetActive(false);
-  }
-
-  public void OnRightButton()
-  {
-    switch (currentWall)
+    enum Wall
     {
-      case Wall.Wall0:
-        Show(Wall.Wall1);
-        break;
-      case Wall.Wall1:
-        Show(Wall.Wall2);
-        break;
-      case Wall.Wall2:
-        Show(Wall.Wall3);
-        break;
-      case Wall.Wall3:
-        Show(Wall.Wall0);
-        break;
+        Wall0,
+        Wall1,
+        Wall2,
+        Wall3,
+        Wall0_0,
+        Wall0_1,
+        Wall0_2,
+        Wall0_3,
+        Wall1_0,
+        Wall1_1,
+        Wall1_2,
+        Wall1_3,
+        Wall1_4,
+        Wall2_0,
+        Wall2_1,
+        Wall2_2,
+        Wall2_3,
+        Wall3_0,
+        Wall3_1,
+        Wall3_2,
     }
-  }
 
-  public void OnLeftButton()
-  {
-    switch (currentWall)
+    Wall currentWall;
+
+    private void Start()
     {
-      case Wall.Wall0:
-        Show(Wall.Wall3);
-        break;
-      case Wall.Wall1:
         Show(Wall.Wall0);
-        break;
-      case Wall.Wall2:
-        Show(Wall.Wall1);
-        break;
-      case Wall.Wall3:
-        Show(Wall.Wall2);
-        break;
     }
-  }
 
-  public void OnBackButton()
-  {
-    switch (currentWall)
+
+    void HideArrows()
     {
-      // 壁0に戻る
-      case Wall.Wall0_0:
-      case Wall.Wall0_1:
-      case Wall.Wall0_3:
-        Show(Wall.Wall0);
-        break;
-      // 宝箱フォーカス解除
-      case Wall.Wall0_2:
+        rightArrow.SetActive(false);
+        leftArrow.SetActive(false);
+        backArrow.SetActive(false);
+    }
+
+    public void OnRightButton()
+    {
+        switch (currentWall)
+        {
+            case Wall.Wall0:
+                Show(Wall.Wall1);
+                break;
+            case Wall.Wall1:
+                Show(Wall.Wall2);
+                break;
+            case Wall.Wall2:
+                Show(Wall.Wall3);
+                break;
+            case Wall.Wall3:
+                Show(Wall.Wall0);
+                break;
+        }
+    }
+
+    public void OnLeftButton()
+    {
+        switch (currentWall)
+        {
+            case Wall.Wall0:
+                Show(Wall.Wall3);
+                break;
+            case Wall.Wall1:
+                Show(Wall.Wall0);
+                break;
+            case Wall.Wall2:
+                Show(Wall.Wall1);
+                break;
+            case Wall.Wall3:
+                Show(Wall.Wall2);
+                break;
+        }
+    }
+
+    public void OnBackButton()
+    {
+        switch (currentWall)
+        {
+            // 壁0に戻る
+            case Wall.Wall0_0:
+            case Wall.Wall0_1:
+            case Wall.Wall0_3:
+                Show(Wall.Wall0);
+                break;
+            // 宝箱フォーカス解除
+            case Wall.Wall0_2:
+                Show(Wall.Wall0_1);
+                break;
+            // 壁1に戻る
+            case Wall.Wall1_0:
+            case Wall.Wall1_2:
+            case Wall.Wall1_4:
+                Show(Wall.Wall1);
+                break;
+            // ゴミ箱フォーカス解除
+            case Wall.Wall1_1:
+                Show(Wall.Wall1_0);
+                break;
+            // レバーBOXフォーカス解除
+            case Wall.Wall1_3:
+                Show(Wall.Wall1_2);
+                break;
+            // 壁2に戻る
+            case Wall.Wall2_0:
+            case Wall.Wall2_1:
+            case Wall.Wall2_2:
+                Show(Wall.Wall2);
+                break;
+            // パスワードBOXフォーカス解除
+            case Wall.Wall2_3:
+                Show(Wall.Wall2_2);
+                break;
+            // 壁3に戻る
+            case Wall.Wall3_0:
+            case Wall.Wall3_2:
+                Show(Wall.Wall3);
+                break;
+            // オセロ金庫フォーカス解除
+            case Wall.Wall3_1:
+                Show(Wall.Wall3_0);
+                break;
+        }
+    }
+
+    // 壁0のフォーカス移動
+    // スイッチBOX
+    public void OnSwitchBox()
+    {
+        Show(Wall.Wall0_0);
+    }
+    // 宝箱
+    public void OnTreasureBox()
+    {
         Show(Wall.Wall0_1);
-        break;
-      // 壁1に戻る
-      case Wall.Wall1_0:
-      case Wall.Wall1_2:
-      case Wall.Wall1_4:
-        Show(Wall.Wall1);
-        break;
-      // ゴミ箱フォーカス解除
-      case Wall.Wall1_1:
-        Show(Wall.Wall1_0);
-        break;
-      // レバーBOXフォーカス解除
-      case Wall.Wall1_3:
-        Show(Wall.Wall1_2);
-        break;
-      // 壁2に戻る
-      case Wall.Wall2_0:
-      case Wall.Wall2_1:
-      case Wall.Wall2_2:
-        Show(Wall.Wall2);
-        break;
-      // パスワードBOXフォーカス解除
-      case Wall.Wall2_3:
-        Show(Wall.Wall2_2);
-        break;
-      // 壁3に戻る
-      case Wall.Wall3_0:
-      case Wall.Wall3_2:
-        Show(Wall.Wall3);
-        break;
-      // オセロ金庫フォーカス解除
-      case Wall.Wall3_1:
-        Show(Wall.Wall3_0);
-        break;
     }
-  }
 
-  // 壁0のフォーカス移動
-  // スイッチBOX
-  public void OnSwitchBox()
-  {
-    Show(Wall.Wall0_0);
-  }
-  // 宝箱
-  public void OnTreasureBox()
-  {
-    Show(Wall.Wall0_1);
-  }
-
-  // 宝箱の南京錠
-  public void OnPadLock()
-  {
-    Show(Wall.Wall0_1);
-  }
-
-  // 白ドア
-  public void OnWhiteDoor()
-  {
-    Show(Wall.Wall0_3);
-  }
-
-  // 壁1のフォーカス移動
-  // ゴミ箱
-  public void OnTrashCan()
-  {
-    Show(Wall.Wall1_0);
-  }
-
-  // ゴミ箱の中
-  public void OnInsideOfTrashCan()
-  {
-    Show(Wall.Wall1_1);
-  }
-
-  // レバーBOX（ハンマー）
-  public void OnLeberBox()
-  {
-    Show(Wall.Wall1_2);
-  }
-
-  // レバーBOXのレバー
-  public void OnLeber()
-  {
-    Show(Wall.Wall1_3);
-  }
-
-  // 棚
-  public void OnShelf()
-  {
-    Show(Wall.Wall1_4);
-  }
-
-  // 壁2のフォーカス移動
-  // カフェラテ
-  public void OnCafellate()
-  {
-    Show(Wall.Wall2_0);
-  }
-
-  // ガラス瓶
-  public void OnGrassBin()
-  {
-    Show(Wall.Wall2_1);
-  }
-
-  // パスワードBOX（暗証番号付きキー）
-  public void OnPasswordBox()
-  {
-    Show(Wall.Wall2_2);
-  }
-
-  // パスワードBOXの入力画面
-  public void OnInputOfPasswordBox()
-  {
-    Show(Wall.Wall2_3);
-  }
-
-  // 壁3のフォーカス移動
-  // 金庫
-  public void OnSafe()
-  {
-    Show(Wall.Wall3_0);
-  }
-
-  // 金庫の入力画面
-  public void OnInputOfSafe()
-  {
-    Show(Wall.Wall3_1);
-  }
-
-  // 壁
-  public void OnWall()
-  {
-    Show(Wall.Wall3_2);
-  }
-
-  void Show(Wall Wall)
-  {
-    HideArrows();
-    currentWall = Wall;
-
-    // 4つの壁
-    switch (Wall)
+    // 宝箱の南京錠
+    public void OnPadLock()
     {
-      case Wall.Wall0:
-        rightArrow.SetActive(true);
-        leftArrow.SetActive(true);
-        transform.localPosition = new Vector2(0, 0);
-        break;
-      case Wall.Wall1:
-        rightArrow.SetActive(true);
-        leftArrow.SetActive(true);
-        transform.localPosition = new Vector2(-1000, 0);
-        break;
-      case Wall.Wall2:
-        rightArrow.SetActive(true);
-        leftArrow.SetActive(true);
-        transform.localPosition = new Vector2(-2000, 0);
-        break;
-      case Wall.Wall3:
-        rightArrow.SetActive(true);
-        leftArrow.SetActive(true);
-        transform.localPosition = new Vector2(-3000, 0);
-        break;
-      case Wall.Wall0_0:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(0, 2000);
-        break;
-      case Wall.Wall0_1:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-1000, 2000);
-        break;
-      case Wall.Wall0_2:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-2000, 2000);
-        break;
-      case Wall.Wall0_3:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-3000, 2000);
-        break;
-      case Wall.Wall1_0:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(0, 4000);
-        break;
-      case Wall.Wall1_1:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-1000, 4000);
-        break;
-      case Wall.Wall1_2:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-2000, 4000);
-        break;
-      case Wall.Wall1_3:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-3000, 4000);
-        break;
-      case Wall.Wall1_4:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-4000, 4000);
-        break;
-      case Wall.Wall2_0:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(0, 6000);
-        break;
-      case Wall.Wall2_1:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-1000, 6000);
-        break;
-      case Wall.Wall2_2:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-2000, 6000);
-        break;
-      case Wall.Wall2_3:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-3000, 6000);
-        break;
-      case Wall.Wall3_0:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(0, 8000);
-        break;
-      case Wall.Wall3_1:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-1000, 8000);
-        break;
-      case Wall.Wall3_2:
-        backArrow.SetActive(true);
-        transform.localPosition = new Vector2(-2000, 8000);
-        break;
-      default:
-        break;
+        Show(Wall.Wall0_1);
     }
-  }
+
+    // 白ドア
+    public void OnWhiteDoor()
+    {
+        Show(Wall.Wall0_3);
+    }
+
+    // 壁1のフォーカス移動
+    // ゴミ箱
+    public void OnTrashCan()
+    {
+        Show(Wall.Wall1_0);
+    }
+
+    // ゴミ箱の中
+    public void OnInsideOfTrashCan()
+    {
+        Show(Wall.Wall1_1);
+    }
+
+    // レバーBOX（ハンマー）
+    public void OnLeberBox()
+    {
+        Show(Wall.Wall1_2);
+    }
+
+    // レバーBOXのレバー
+    public void OnLeber()
+    {
+        Show(Wall.Wall1_3);
+    }
+
+    // 棚
+    public void OnShelf()
+    {
+        Show(Wall.Wall1_4);
+    }
+
+    // 壁2のフォーカス移動
+    // カフェラテ
+    public void OnCafellate()
+    {
+        Show(Wall.Wall2_0);
+    }
+
+    // ガラス瓶
+    public void OnGrassBin()
+    {
+        Show(Wall.Wall2_1);
+    }
+
+    // パスワードBOX（暗証番号付きキー）
+    public void OnPasswordBox()
+    {
+        Show(Wall.Wall2_2);
+    }
+
+    // パスワードBOXの入力画面
+    public void OnInputOfPasswordBox()
+    {
+        Show(Wall.Wall2_3);
+    }
+
+    // 壁3のフォーカス移動
+    // 金庫
+    public void OnSafe()
+    {
+        Show(Wall.Wall3_0);
+    }
+
+    // 金庫の入力画面
+    public void OnInputOfSafe()
+    {
+        Show(Wall.Wall3_1);
+    }
+
+    // 壁
+    public void OnWall()
+    {
+        Show(Wall.Wall3_2);
+    }
+
+    void Show(Wall Wall)
+    {
+        HideArrows();
+        currentWall = Wall;
+
+        // 4つの壁
+        switch (Wall)
+        {
+            case Wall.Wall0:
+                rightArrow.SetActive(true);
+                leftArrow.SetActive(true);
+                transform.localPosition = new Vector2(0, 0);
+                break;
+            case Wall.Wall1:
+                rightArrow.SetActive(true);
+                leftArrow.SetActive(true);
+                transform.localPosition = new Vector2(-1000, 0);
+                break;
+            case Wall.Wall2:
+                rightArrow.SetActive(true);
+                leftArrow.SetActive(true);
+                transform.localPosition = new Vector2(-2000, 0);
+                break;
+            case Wall.Wall3:
+                rightArrow.SetActive(true);
+                leftArrow.SetActive(true);
+                transform.localPosition = new Vector2(-3000, 0);
+                break;
+            case Wall.Wall0_0:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(0, 2000);
+                break;
+            case Wall.Wall0_1:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-1000, 2000);
+                break;
+            case Wall.Wall0_2:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-2000, 2000);
+                break;
+            case Wall.Wall0_3:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-3000, 2000);
+                break;
+            case Wall.Wall1_0:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(0, 4000);
+                break;
+            case Wall.Wall1_1:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-1000, 4000);
+                break;
+            case Wall.Wall1_2:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-2000, 4000);
+                break;
+            case Wall.Wall1_3:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-3000, 4000);
+                break;
+            case Wall.Wall1_4:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-4000, 4000);
+                break;
+            case Wall.Wall2_0:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(0, 6000);
+                break;
+            case Wall.Wall2_1:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-1000, 6000);
+                break;
+            case Wall.Wall2_2:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-2000, 6000);
+                break;
+            case Wall.Wall2_3:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-3000, 6000);
+                break;
+            case Wall.Wall3_0:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(0, 8000);
+                break;
+            case Wall.Wall3_1:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-1000, 8000);
+                break;
+            case Wall.Wall3_2:
+                backArrow.SetActive(true);
+                transform.localPosition = new Vector2(-2000, 8000);
+                break;
+            default:
+                break;
+        }
+    }
 }

--- a/Assets/Scripts/WallChanger.cs
+++ b/Assets/Scripts/WallChanger.cs
@@ -326,6 +326,8 @@ public class WallChanger : MonoBehaviour
         backArrow.SetActive(true);
         transform.localPosition = new Vector2(-2000, 8000);
         break;
+      default:
+        break;
     }
   }
 }

--- a/Assets/Scripts/ZoomPanel.cs
+++ b/Assets/Scripts/ZoomPanel.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ZoomPanel : MonoBehaviour
+{
+    [SerializeField] GameObject panel = default;
+
+    [SerializeField] GameObject rightArrow;
+    [SerializeField] GameObject leftArrow;
+
+    [SerializeField] GameObject backArrow;
+
+    private bool isShow = false;
+
+    public void ChangePanel()
+    {
+        Item item = ItemBox.instance.GetSelectedItem();
+        if (item != null && ItemBox.instance.selectCount == 1 && !isShow)
+        {
+            OpenPanel();
+        }
+        else if (ItemBox.instance.selectCount == 2 && isShow)
+        {
+            ClosePanel();
+        }
+    }
+
+    // アイテムを選択かつアイテムが2回押されたら
+    // 拡大表示
+    public void OpenPanel()
+    {
+        isShow = true;
+        ItemBox.instance.selectCount++;
+        Debug.Log(ItemBox.instance.selectCount);
+        panel.SetActive(true);
+        rightArrow.SetActive(false);
+        leftArrow.SetActive(false);
+        backArrow.SetActive(true);
+    }
+
+    // 戻るボタンorアイテムが押されたら
+    // 拡大表示を閉じる
+    public void ClosePanel()
+    {
+        isShow = false;
+        ItemBox.instance.selectCount--;
+        Debug.Log(ItemBox.instance.selectCount);
+        panel.SetActive(false);
+        rightArrow.SetActive(true);
+        leftArrow.SetActive(true);
+        backArrow.SetActive(false);
+    }
+}

--- a/Assets/Scripts/ZoomPanel.cs
+++ b/Assets/Scripts/ZoomPanel.cs
@@ -5,50 +5,63 @@ using UnityEngine;
 public class ZoomPanel : MonoBehaviour
 {
     [SerializeField] GameObject panel = default;
+    [SerializeField] GameObject wallParent;
 
     [SerializeField] GameObject rightArrow;
     [SerializeField] GameObject leftArrow;
 
     [SerializeField] GameObject backArrow;
 
-    private bool isShow = false;
+    public bool isShow = false;
 
-    public void ChangePanel()
-    {
-        Item item = ItemBox.instance.GetSelectedItem();
-        if (item != null && ItemBox.instance.selectCount == 1 && !isShow)
-        {
-            OpenPanel();
-        }
-        else if (ItemBox.instance.selectCount == 2 && isShow)
-        {
-            ClosePanel();
-        }
-    }
+    // int selectCount = ItemBox.instance.selectCount;
+
+    public int selectCount = 0;
+
+    Item beforeItem;
 
     // アイテムを選択かつアイテムが2回押されたら
     // 拡大表示
     public void OpenPanel()
     {
-        isShow = true;
-        ItemBox.instance.selectCount++;
-        Debug.Log(ItemBox.instance.selectCount);
-        panel.SetActive(true);
-        rightArrow.SetActive(false);
-        leftArrow.SetActive(false);
-        backArrow.SetActive(true);
+        Item currentItem = ItemBox.instance.GetSelectedItem();
+        if (selectCount == 0 && !isShow)
+        {
+            selectCount = 1;
+            beforeItem = currentItem;
+            return;
+        }
+        if (currentItem == beforeItem && selectCount == 1 && !isShow)
+        {
+            isShow = true;
+            selectCount = 2;
+            panel.SetActive(true);
+            rightArrow.SetActive(false);
+            leftArrow.SetActive(false);
+            backArrow.SetActive(true);
+            beforeItem = currentItem;
+        }
+        beforeItem = currentItem;
     }
 
     // 戻るボタンorアイテムが押されたら
     // 拡大表示を閉じる
     public void ClosePanel()
     {
-        isShow = false;
-        ItemBox.instance.selectCount--;
-        Debug.Log(ItemBox.instance.selectCount);
-        panel.SetActive(false);
-        rightArrow.SetActive(true);
-        leftArrow.SetActive(true);
-        backArrow.SetActive(false);
+        Item currentItem = ItemBox.instance.GetSelectedItem();
+        if (selectCount == 2 && isShow)
+        {
+            isShow = false;
+            selectCount = 1;
+            panel.SetActive(false);
+
+            // フォーカスしてる状態で拡大表示->削除するときは、左右ボタンいらない
+            if (wallParent.GetComponent<Transform>().localPosition.y == 0)
+            {
+                rightArrow.SetActive(true);
+                leftArrow.SetActive(true);
+            }
+            backArrow.SetActive(false);
+        }
     }
 }


### PR DESCRIPTION
## 実装した点

- アイテムの拡大表示
  - 各Slotに、ItemBox::OnSelectSlot->ZoomPanel::OpenPanelの順で実行するようボタンを設定
  - アイテムを1回押したら選択状態になる( OnSelectSlot )
  - 1回選択されている状態だったら  
    - 選択カウントを1にする
    - 選択アイテムを保持
  - 2回選択されたら(選択カウントが1だったら)
    - 保持しているアイテムと今回選択したアイテムが同じかを確認し、同じだったら以下を実行
      - 表示フラグをtrue
      - 選択カウントを2にする
      - 矢印表示を変更
      - 選択アイテムを保持
      - 下矢印を表示
  - 拡大表示してる状態で下矢印を押したら
    - 選択カウントが2かつ表示フラグがtrueだった場合のみ以下を実行
       - 表示フラグをfalse
       - 選択カウントを1にする
      - 拡大表示用のパネルを非表示
      - 左右矢印ボタンを表示
      - オブジェクトにフォーカスしてる状態で拡大表示を削除する場合は、左右ボタンいらない(フォーカス画面は下矢印のみ)ので、下矢印を押した時にwallParentのy座標が0だった場合のみ左右矢印ボタンを表示するようにした
  - その他の条件下でも選択したアイテムを保持する
- インデント補正

## 詰まった点・残課題

- Udemyの課題動画では虫眼鏡ボタンを押すと拡大だったが、今回は2回押すと拡大表示をしたかったため、別のアイテムを押した時のフラグ管理が面倒だった
  - 前選択したアイテムを保持しておいて、その次に選択したアイテムが同じアイテムだったら拡大表示、違ったら何もしないという処理を実装