### PR TITLE
fix: 選択したアイテムが拡大表示されるように修正

### DIFF
--- a/Assets/Scenes/WhiteRoom.unity
+++ b/Assets/Scenes/WhiteRoom.unity
@@ -495,7 +495,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &85797701
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1322,7 +1322,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &191629528
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2319,7 +2319,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &326854040
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3489,7 +3489,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &407958395
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5110,7 +5110,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &671563212
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6532,7 +6532,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1012040120
 RectTransform:
   m_ObjectHideFlags: 0
@@ -8419,7 +8419,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1000, y: 4000}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 750, y: 1334}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1326768896
@@ -11555,7 +11555,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1881014254
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13052,7 +13052,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2112451094
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13241,7 +13241,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2141813253
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -13,13 +13,15 @@ public class Item
         Hammer,
     }
 
-    public Type type;         // 種類
-    public Sprite sprite;     // Slotに表示する画像
+    public Type type;               // 種類
+    public Sprite sprite;           // Slotに表示する画像
+    public Sprite zoomImage;    // 拡大表示する画像   
 
     // 型
-    public Item(Type type, Sprite sprite)
+    public Item(Type type, Sprite sprite, Sprite zoomImage)
     {
         this.type = type;
         this.sprite = sprite;
+        this.zoomImage = zoomImage;
     }
 }

--- a/Assets/Scripts/ItemGenerator.cs
+++ b/Assets/Scripts/ItemGenerator.cs
@@ -22,7 +22,19 @@ public class ItemGenerator : MonoBehaviour
         {
             if (item.type == type)
             {
-                return new Item(item.type, item.sprite);
+                return new Item(item.type, item.sprite, item.zoomImage);
+            }
+        }
+        return null;
+    }
+
+    public Sprite GetZoomImage(Item.Type type)
+    {
+        foreach (Item item in itemListEntity.itemList)
+        {
+            if (item.type == type)
+            {
+                return item.zoomImage;
             }
         }
         return null;

--- a/Assets/Scripts/ZoomPanel.cs
+++ b/Assets/Scripts/ZoomPanel.cs
@@ -1,11 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class ZoomPanel : MonoBehaviour
 {
     [SerializeField] GameObject panel = default;
     [SerializeField] GameObject wallParent;
+    [SerializeField] GameObject zoomImageObj;
+    public Image zoomImage;
 
     [SerializeField] GameObject rightArrow;
     [SerializeField] GameObject leftArrow;
@@ -20,6 +23,11 @@ public class ZoomPanel : MonoBehaviour
 
     Item beforeItem;
 
+    private void Start()
+    {
+        zoomImage = zoomImageObj.GetComponent<Image>();
+    }
+
     // アイテムを選択かつアイテムが2回押されたら
     // 拡大表示
     public void OpenPanel()
@@ -28,8 +36,6 @@ public class ZoomPanel : MonoBehaviour
         if (selectCount == 0 && !isShow)
         {
             selectCount = 1;
-            beforeItem = currentItem;
-            return;
         }
         if (currentItem == beforeItem && selectCount == 1 && !isShow)
         {
@@ -39,8 +45,8 @@ public class ZoomPanel : MonoBehaviour
             rightArrow.SetActive(false);
             leftArrow.SetActive(false);
             backArrow.SetActive(true);
-            beforeItem = currentItem;
         }
+        zoomImage.sprite = ItemGenerator.instance.GetZoomImage(currentItem.type);
         beforeItem = currentItem;
     }
 


### PR DESCRIPTION
## 実装した点

- データベースのitemListを探し、選択したアイテムと同じタイプのアイテムがあればそのzoomImageを返す関数をItemGeneratorに作成
- zoomPanelで呼び出し、選択したアイテムにあった画像を拡大表示するようにした
  - boforeItemの作成と画像表示は分岐が不要だったので外に出した